### PR TITLE
Provide temporary fix for latest version detection

### DIFF
--- a/data/latestVersion.json
+++ b/data/latestVersion.json
@@ -1,0 +1,3 @@
+{
+  "latestVersion": "1.2.0"
+}


### PR DESCRIPTION
With the repo project folder restructure for the **1.3.0 Milestone**, an unfortunate side effect for older versions of nvQuickSite was that it could not access the old location for detecting the latest version.  Resolves #200