### PR TITLE
Move install package list to GitHub and add potential future support for distributions

### DIFF
--- a/nvQuickSite/ComboItem.cs
+++ b/nvQuickSite/ComboItem.cs
@@ -30,7 +30,7 @@ namespace nvQuickSite
 
         public override string ToString()
         {
-            return Value;
+            return Name;
         }
     }
 }

--- a/nvQuickSite/Controllers/PackageController.cs
+++ b/nvQuickSite/Controllers/PackageController.cs
@@ -1,0 +1,70 @@
+﻿using nvQuickSite.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+
+namespace nvQuickSite.Controllers
+{
+    public class PackageController
+    {
+        public static IEnumerable<Package> GetPackageList()
+        {
+            var localPackages = GetLocalPackages();
+            var packages = localPackages.ToList();
+            var remotePackages = GetRemotePackages();
+            if (remotePackages.Count() > 0)
+            {
+                packages = localPackages.Where(p => p.keep == true).ToList();
+                foreach (var package in remotePackages)
+                {
+                    if (packages.SingleOrDefault(p => p.did == package.did && p.version == package.version) == null)
+                    {
+                        packages.Add(package);
+                    }
+                }
+            }
+            SaveLocalPackagesFile(packages);
+            return packages;
+        }
+        private static void SaveLocalPackagesFile(IEnumerable<Package> packages)
+        {
+            var pfile = System.IO.Directory.GetCurrentDirectory() + @"\Downloads\packages.json";
+            using (var sw = new System.IO.StreamWriter(pfile))
+            {
+                sw.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(packages, Newtonsoft.Json.Formatting.Indented));
+            }
+        }
+        private static IEnumerable<Package> GetLocalPackages()
+        {
+            var res = new List<Package>();
+            var pfile = System.IO.Directory.GetCurrentDirectory() + @"\Downloads\packages.json";
+            if (System.IO.File.Exists(pfile))
+            {
+                using (var sr = new System.IO.StreamReader(pfile))
+                {
+                    var content = sr.ReadToEnd();
+                    res = Newtonsoft.Json.JsonConvert.DeserializeObject<List<Package>>(content);
+                }
+            }
+            return res;
+        }
+        private static IEnumerable<Package> GetRemotePackages()
+        {
+            WebClient client = new WebClient();
+            try
+            {
+                var url = "https://github.com/nvisionative/nvQuickSite/blob/master/data/packages.json";
+                string result = client.DownloadString(url);
+                var res = Newtonsoft.Json.JsonConvert.DeserializeObject<IEnumerable<Package>>(result);
+                return res;
+            }
+            catch (Exception ex)
+            {
+            }
+            return new List<Package>();
+        }
+
+    }
+}

--- a/nvQuickSite/Models/Package.cs
+++ b/nvQuickSite/Models/Package.cs
@@ -1,0 +1,12 @@
+﻿namespace nvQuickSite.Models
+{
+    public class Package
+    {
+        public string did { get; set; }
+        public string name { get; set; }
+        public string version { get; set; }
+        public string url { get; set; }
+        public string upgradeurl { get; set; }
+        public bool keep { get; set; } = false;
+    }
+}

--- a/nvQuickSite/Start.Designer.cs
+++ b/nvQuickSite/Start.Designer.cs
@@ -43,13 +43,14 @@
             this.txtSiteNamePrefix = new MetroFramework.Controls.MetroTextBox();
             this.toggleSiteInfoRemember = new MetroFramework.Controls.MetroToggle();
             this.tabInstallPackage = new MetroFramework.Controls.MetroTabPage();
+            this.cboProductVersion = new MetroFramework.Controls.MetroComboBox();
             this.progressBarDownload = new MetroFramework.Controls.MetroProgressBar();
             this.btnInstallPackageNext = new MetroFramework.Controls.MetroButton();
             this.btnLocalInstallPackage = new MetroFramework.Controls.MetroButton();
             this.txtLocalInstallPackage = new MetroFramework.Controls.MetroTextBox();
             this.lblLatestReleases = new MetroFramework.Controls.MetroLabel();
             this.lblLocalInstallPackage = new MetroFramework.Controls.MetroLabel();
-            this.cboLatestReleases = new MetroFramework.Controls.MetroComboBox();
+            this.cboProductName = new MetroFramework.Controls.MetroComboBox();
             this.btnGetLatestRelease = new MetroFramework.Controls.MetroButton();
             this.btnViewAllReleases = new MetroFramework.Controls.MetroButton();
             this.tabControl = new MetroFramework.Controls.MetroTabControl();
@@ -238,13 +239,14 @@
             // 
             // tabInstallPackage
             // 
+            this.tabInstallPackage.Controls.Add(this.cboProductVersion);
             this.tabInstallPackage.Controls.Add(this.progressBarDownload);
             this.tabInstallPackage.Controls.Add(this.btnInstallPackageNext);
             this.tabInstallPackage.Controls.Add(this.btnLocalInstallPackage);
             this.tabInstallPackage.Controls.Add(this.txtLocalInstallPackage);
             this.tabInstallPackage.Controls.Add(this.lblLatestReleases);
             this.tabInstallPackage.Controls.Add(this.lblLocalInstallPackage);
-            this.tabInstallPackage.Controls.Add(this.cboLatestReleases);
+            this.tabInstallPackage.Controls.Add(this.cboProductName);
             this.tabInstallPackage.Controls.Add(this.btnGetLatestRelease);
             this.tabInstallPackage.Controls.Add(this.btnViewAllReleases);
             this.tabInstallPackage.HorizontalScrollbarBarColor = true;
@@ -254,6 +256,16 @@
             this.tabInstallPackage.TabIndex = 0;
             this.tabInstallPackage.Text = "Install Package Info";
             this.tabInstallPackage.VerticalScrollbarBarColor = true;
+            // 
+            // cboProductVersion
+            // 
+            this.cboProductVersion.FormattingEnabled = true;
+            this.cboProductVersion.ItemHeight = 23;
+            this.cboProductVersion.Location = new System.Drawing.Point(417, 33);
+            this.cboProductVersion.Name = "cboProductVersion";
+            this.cboProductVersion.Size = new System.Drawing.Size(123, 29);
+            this.cboProductVersion.TabIndex = 30;
+            this.cboProductVersion.SelectedIndexChanged += new System.EventHandler(this.cboProductVersion_SelectedIndexChanged);
             // 
             // progressBarDownload
             // 
@@ -313,15 +325,15 @@
             this.lblLocalInstallPackage.TabIndex = 25;
             this.lblLocalInstallPackage.Text = "Local Install Package";
             // 
-            // cboLatestReleases
+            // cboProductName
             // 
-            this.cboLatestReleases.FormattingEnabled = true;
-            this.cboLatestReleases.ItemHeight = 23;
-            this.cboLatestReleases.Location = new System.Drawing.Point(1, 33);
-            this.cboLatestReleases.Name = "cboLatestReleases";
-            this.cboLatestReleases.Size = new System.Drawing.Size(539, 29);
-            this.cboLatestReleases.TabIndex = 21;
-            this.cboLatestReleases.SelectedIndexChanged += new System.EventHandler(this.cboLatestReleases_SelectedIndexChanged);
+            this.cboProductName.FormattingEnabled = true;
+            this.cboProductName.ItemHeight = 23;
+            this.cboProductName.Location = new System.Drawing.Point(1, 33);
+            this.cboProductName.Name = "cboProductName";
+            this.cboProductName.Size = new System.Drawing.Size(410, 29);
+            this.cboProductName.TabIndex = 31;
+            this.cboProductName.SelectedIndexChanged += new System.EventHandler(this.cboProductName_SelectedIndexChanged);
             // 
             // btnGetLatestRelease
             // 
@@ -353,7 +365,7 @@
             this.tabControl.Location = new System.Drawing.Point(3, 14);
             this.tabControl.Multiline = true;
             this.tabControl.Name = "tabControl";
-            this.tabControl.SelectedIndex = 1;
+            this.tabControl.SelectedIndex = 0;
             this.tabControl.Size = new System.Drawing.Size(607, 294);
             this.tabControl.TabIndex = 26;
             // 
@@ -648,7 +660,8 @@
         private MetroFramework.Controls.MetroLabel lblLocalInstallPackage;
         private MetroFramework.Controls.MetroLabel lblLatestReleases;
         private MetroFramework.Controls.MetroButton btnViewAllReleases;
-        private MetroFramework.Controls.MetroComboBox cboLatestReleases;
+        //private MetroFramework.Controls.MetroComboBox cboLatestReleases;
+        private MetroFramework.Controls.MetroComboBox cboProductName;
         private MetroFramework.Controls.MetroButton btnGetLatestRelease;
         private MetroFramework.Controls.MetroTabControl tabControl;
         private MetroFramework.Controls.MetroTile tileQuickStartGuide;
@@ -690,5 +703,6 @@
         private MetroFramework.Controls.MetroTextBox txtSiteNameSuffix;
         private MetroFramework.Controls.MetroLabel lblInstallSubFolder;
         private MetroFramework.Controls.MetroTextBox txtInstallSubFolder;
+        private MetroFramework.Controls.MetroComboBox cboProductVersion;
     }
 }

--- a/nvQuickSite/data/packages.json
+++ b/nvQuickSite/data/packages.json
@@ -1,0 +1,317 @@
+﻿[
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "9.3.1",
+    "url": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.3.1/DNN_Platform_9.3.1.2_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.3.1/DNN_Platform_9.3.1.2_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "9.2.2",
+    "url": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.2.2/DNN_Platform_9.2.2.178_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.2.2/DNN_Platform_9.2.2.178_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "9.2.1",
+    "url": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.2.1/DNN_Platform_9.2.1.533-298_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.2.1/DNN_Platform_9.2.1.533-298_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "9.2.0",
+    "url": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.2.0/DNN_Platform_9.2.0.366-777_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.2.0/DNN_Platform_9.2.0.366-777_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "9.1.1",
+    "url": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.1.1/DNN_Platform_9.1.1.129-232_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.1.1/DNN_Platform_9.1.1.129-232_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "9.1.0",
+    "url": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.1.0/DNN_Platform_9.1.0.367_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.1.0/DNN_Platform_9.1.0.367_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "9.0.2",
+    "url": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.0.2/DNN_Platform_9.0.2_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.0.2/DNN_Platform_9.0.2_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "9.0.1",
+    "url": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.0.1/DNN_Platform_9.0.1.142_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.0.1/DNN_Platform_9.0.1.142_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "9.0.0",
+    "url": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.0.0/DNN_Platform_9.0.0.1002_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Platform/releases/download/v9.0.0/DNN_Platform_9.0.0.1002_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "8.0.4",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.8x/raw/master/08.00.04/DNN_Platform_8.0.4.226_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.8x/raw/master/08.00.04/DNN_Platform_8.0.4.226_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "8.0.3",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.8x/raw/master/08.00.03/DNN_Platform_8.0.3_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.8x/raw/master/08.00.03/DNN_Platform_8.0.3_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "8.0.2",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.8x/raw/master/08.00.02/DNN_Platform_8.0.2_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.8x/raw/master/08.00.02/DNN_Platform_8.0.2_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "8.0.1",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.8x/raw/master/08.00.01/DNN_Platform_8.0.1.236_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.8x/raw/master/08.00.01/DNN_Platform_8.0.1.236_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "8.0.0",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.8x/raw/master/08.00.00/DNN_Platform_8.0.0_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.8x/raw/master/08.00.00/DNN_Platform_8.0.0_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "7.4.2",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.04.02/DNN_Platform_07.04.02_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.04.02/DNN_Platform_07.04.02_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "7.4.1",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.04.01/DNN_Platform_07.04.01_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.04.01/DNN_Platform_07.04.01_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "7.4.0",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.04.00/DNN_Platform_07.04.00_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.04.00/DNN_Platform_07.04.00_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "7.3.4",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.03.04/DNN_Platform_07.03.04_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.03.04/DNN_Platform_07.03.04_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "7.3.3",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.03.03/DNN_Platform_07.03.03_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.03.03/DNN_Platform_07.03.03_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "7.3.2",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.03.02/DNN_Platform_07.03.02_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.03.02/DNN_Platform_07.03.02_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "7.3.1",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.03.01/DNN_Platform_07.03.01_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.03.01/DNN_Platform_07.03.01_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "7.3.0",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.03.00/DNN_Platform_07.03.00_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.03.00/DNN_Platform_07.03.00_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "7.2.2",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.02.02/DNN_Platform_07.02.02_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.02.02/DNN_Platform_07.02.02_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "7.2.1",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.02.01/DNN_Platform_07.02.01_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.02.01/DNN_Platform_07.02.01_Upgrade.zip"
+  },
+  {
+    "did": "dnn-platform",
+    "name": "DNN Platform",
+    "version": "7.2.0",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.02.00/DNN_Platform_07.02.00_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.02.00/DNN_Platform_07.02.00_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "7.1.2",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.01.02/DotNetNuke_Community_07.01.02_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.01.02/DotNetNuke_Community_07.01.02_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "7.1.1",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.01.01/DotNetNuke_Community_07.01.01_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.01.01/DotNetNuke_Community_07.01.01_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "7.1.0",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.01.00/DotNetNuke_Community_07.01.00_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.01.00/DotNetNuke_Community_07.01.00_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "7.0.6",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.00.06/DotNetNuke_Community_07.00.06_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.00.06/DotNetNuke_Community_07.00.06_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "7.0.5",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.00.05/DotNetNuke_Community_07.00.05_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.00.05/DotNetNuke_Community_07.00.05_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "7.0.4",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.00.04/DotNetNuke_Community_07.00.04_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.00.04/DotNetNuke_Community_07.00.04_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "7.0.3",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.00.03/DotNetNuke_Community_07.00.03_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.00.03/DotNetNuke_Community_07.00.03_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "7.0.2",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.00.02/DotNetNuke_Community_07.00.02_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.00.02/DotNetNuke_Community_07.00.02_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "7.0.1",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.00.01/DotNetNuke_Community_07.00.01_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.00.01/DotNetNuke_Community_07.00.01_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "7.0.0",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.00.00/DotNetNuke_Community_07.00.00_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.7x/raw/master/07.00.00/DotNetNuke_Community_07.00.00_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "6.2.9",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.09/DotNetNuke_Community_06.02.09_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.09/DotNetNuke_Community_06.02.09_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "6.2.8",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.08/DotNetNuke_Community_06.02.08_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.08/DotNetNuke_Community_06.02.08_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "6.2.7",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.07/DotNetNuke_Community_06.02.07_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.07/DotNetNuke_Community_06.02.07_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "6.2.6",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.06/DotNetNuke_Community_06.02.06_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.06/DotNetNuke_Community_06.02.06_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "6.2.5",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.05/DotNetNuke_Community_06.02.05_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.05/DotNetNuke_Community_06.02.05_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "6.2.4",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.04/DotNetNuke_Community_06.02.04_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.04/DotNetNuke_Community_06.02.04_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "6.2.3",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.03/DotNetNuke_Community_06.02.03_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.03/DotNetNuke_Community_06.02.03_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "6.2.2",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.02/DotNetNuke_Community_06.02.02_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.02/DotNetNuke_Community_06.02.02_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "6.2.1",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.01/DotNetNuke_Community_06.02.01_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.01/DotNetNuke_Community_06.02.01_Upgrade.zip"
+  },
+  {
+    "did": "dotnetnuke-community",
+    "name": "DotNetNuke Community",
+    "version": "6.2.0",
+    "url": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.00/DotNetNuke_Community_06.02.00_Install.zip",
+    "upgradeurl": "https://github.com/dnnsoftware/Dnn.Releases.Archive.6x/raw/master/06.02.00/DotNetNuke_Community_06.02.00_Upgrade.zip"
+  }
+]

--- a/nvQuickSite/nvQuickSite.csproj
+++ b/nvQuickSite/nvQuickSite.csproj
@@ -130,7 +130,9 @@
   <ItemGroup>
     <Compile Include="CodePlexRSS.cs" />
     <Compile Include="ComboItem.cs" />
+    <Compile Include="Controllers\PackageController.cs" />
     <Compile Include="Controllers\VersionController.cs" />
+    <Compile Include="Models\Package.cs" />
     <Compile Include="Models\Version.cs" />
     <Compile Include="MsgBoxYesNoIgnore.cs">
       <SubType>Form</SubType>
@@ -176,6 +178,7 @@
     <None Include=".gitignore" />
     <None Include="app.config" />
     <None Include="data\latestVersion.json" />
+    <None Include="data\packages.json" />
     <None Include="LICENSE.md" />
     <None Include="packages.config">
       <SubType>Designer</SubType>


### PR DESCRIPTION
This is a significant update that resolves #128.  No longer will nvisionative need to manually download and host DNN installation packages post-release.  Also, the manifest has been moved from an nvisionative hosted XML file to a GitHub hosted JSON file.  

For now:
- DNN 9.x install packages are pulled from dnnsoftware/Dnn.Platform
- DNN 8.x install packages are pulled from dnnsoftware/Dnn.Releases.Archive.8x
- DNN 7.x install packages are pulled from dnnsoftware/Dnn.Releases.Archive.7x
- DNN 6.x install packages are pulled from dnnsoftware/Dnn.Releases.Archive.6x

You'll also notice we have stayed true to the historical naming convention for **DNN Platform** and **DotNetNuke Community**.

Not only does this help with the above this pull request also resolves #133.  It paves the way for future support of "distributions".  Please see the referenced issue for more information on this.

<img width="652" alt="Screenshot 2019-04-11 01 20 15" src="https://user-images.githubusercontent.com/4568451/55932519-0840eb00-5bf8-11e9-9006-3d47b3343898.png">
