### PR TITLE
Allows deleting a site that is not started

### DIFF
--- a/nvQuickSite/Controllers/DatabaseController.cs
+++ b/nvQuickSite/Controllers/DatabaseController.cs
@@ -241,5 +241,28 @@ namespace nvQuickSite.Controllers
 
             Log.Logger.Information("Permissions set for database {dbName}", this.dbName);
         }
+
+        /// <summary>
+        /// Deletes a database and optionally provides a progress report.
+        /// </summary>
+        /// <param name="progress">An optional progress reporter.</param>
+        internal void DeleteDatabase(IProgress<int> progress)
+        {
+            Log.Information($"Deleting database {this.dbName}");
+            progress?.Report(25);
+            try
+            {
+                progress?.Report(75);
+                this.DropDatabase();
+            }
+            catch (DatabaseControllerException ex)
+            {
+                var message = $"Could not delete database {this.dbName}";
+                Log.Logger.Error(message, ex);
+                throw new ArgumentException(message) { Source = "Delete Database Error" };
+            }
+
+            progress?.Report(100);
+        }
     }
 }

--- a/nvQuickSite/Controllers/FileSystemController.cs
+++ b/nvQuickSite/Controllers/FileSystemController.cs
@@ -21,6 +21,7 @@ namespace nvQuickSite.Controllers
     using System.IO;
     using System.Linq;
     using System.Security.AccessControl;
+    using System.Threading;
     using System.Xml.Linq;
 
     using nvQuickSite.Controllers.Exceptions;
@@ -50,6 +51,7 @@ namespace nvQuickSite.Controllers
         /// <param name="progress">A progress reported (optional).</param>
         internal static void RemoveHostEntry(string siteName, IProgress<int> progress = null)
         {
+            Log.Logger.Information("Removing host file entry for {siteName}", siteName);
             string tempFile = hostsFile + ".new";
             var lineCount = File.ReadAllLines(hostsFile).Length;
             int currentLine = 0;
@@ -77,6 +79,7 @@ namespace nvQuickSite.Controllers
 
             File.Delete(hostsFile);
             File.Move(tempFile, hostsFile);
+            Log.Logger.Debug("{hostsfile} replaced", hostsFile);
 
             progress?.Report(100);
         }
@@ -323,6 +326,8 @@ namespace nvQuickSite.Controllers
         /// <param name="progress">Reports progress by firing up for each file or folder with it's name.</param>
         internal static void DeleteDirectory(string targetDir, IProgress<string> progress = null)
         {
+            Log.Logger.Information("Deleting directory {targetDir}", targetDir);
+
             try
             {
                 string[] files = Directory.GetFiles(targetDir);


### PR DESCRIPTION
Closes #282

- Refactored some methods to not mix reusable logic with the UI focused classes.
- Added more logging in the sites deletion code paths.
- Reworked site and appPool stopping logic to avoid throwing exceptions on states that don't prevent the site deletion.