### PR TITLE
Fixed an issue where the wrong version of Newtonsoft.Json was defined

### DIFF
--- a/nvQuickSite/nvQuickSite.csproj
+++ b/nvQuickSite/nvQuickSite.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+	<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{3D661BAD-45EB-4524-9650-78805CD31682}</ProjectGuid>


### PR DESCRIPTION
We recently bumped this dependency but other dependencies also depend on this library. This PR makes the system auto-generate the required binding redirects if necessary to fix that issue.