### PR TITLE
Implement support for enabling SSL

### DIFF
--- a/nvQuickSite/Properties/AssemblyInfo.cs
+++ b/nvQuickSite/Properties/AssemblyInfo.cs
@@ -49,6 +49,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.2.0")]
-[assembly: AssemblyFileVersion("2.2.0")]
+[assembly: AssemblyVersion("2.3.0")]
+[assembly: AssemblyFileVersion("2.3.0")]
 [assembly: NeutralResourcesLanguage("en")]

--- a/nvQuickSite/Properties/Settings.Designer.cs
+++ b/nvQuickSite/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace nvQuickSite.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -200,6 +200,30 @@ namespace nvQuickSite.Properties {
             }
             set {
                 this["EnableLocalPackageInstall"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool EnableSsl {
+            get {
+                return ((bool)(this["EnableSsl"]));
+            }
+            set {
+                this["EnableSsl"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string CertificateFriendlyName {
+            get {
+                return ((string)(this["CertificateFriendlyName"]));
+            }
+            set {
+                this["CertificateFriendlyName"] = value;
             }
         }
     }

--- a/nvQuickSite/Properties/Settings.settings
+++ b/nvQuickSite/Properties/Settings.settings
@@ -47,5 +47,11 @@
     <Setting Name="EnableLocalPackageInstall" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="EnableSsl" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="CertificateFriendlyName" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/nvQuickSite/Start.Designer.cs
+++ b/nvQuickSite/Start.Designer.cs
@@ -29,6 +29,8 @@
         private void InitializeComponent()
         {
             this.tabSiteInfo = new MetroFramework.Controls.MetroTabPage();
+            this.cboCertificates = new MetroFramework.Controls.MetroComboBox();
+            this.chkEnableSsl = new MetroFramework.Controls.MetroCheckBox();
             this.lblInstallSubFolder = new MetroFramework.Controls.MetroLabel();
             this.txtInstallSubFolder = new MetroFramework.Controls.MetroTextBox();
             this.txtSiteNameSuffix = new MetroFramework.Controls.MetroTextBox();
@@ -87,6 +89,8 @@
             // 
             // tabSiteInfo
             // 
+            this.tabSiteInfo.Controls.Add(this.cboCertificates);
+            this.tabSiteInfo.Controls.Add(this.chkEnableSsl);
             this.tabSiteInfo.Controls.Add(this.lblInstallSubFolder);
             this.tabSiteInfo.Controls.Add(this.txtInstallSubFolder);
             this.tabSiteInfo.Controls.Add(this.txtSiteNameSuffix);
@@ -107,6 +111,28 @@
             this.tabSiteInfo.Text = "Site Info";
             this.tabSiteInfo.VerticalScrollbarBarColor = true;
             // 
+            // cboCertificates
+            // 
+            this.cboCertificates.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.cboCertificates.FormattingEnabled = true;
+            this.cboCertificates.ItemHeight = 23;
+            this.cboCertificates.Location = new System.Drawing.Point(323, 99);
+            this.cboCertificates.Name = "cboCertificates";
+            this.cboCertificates.Size = new System.Drawing.Size(273, 29);
+            this.cboCertificates.TabIndex = 31;
+            this.cboCertificates.Visible = false;
+            // 
+            // chkEnableSsl
+            // 
+            this.chkEnableSsl.AutoSize = true;
+            this.chkEnableSsl.Location = new System.Drawing.Point(323, 82);
+            this.chkEnableSsl.Name = "chkEnableSsl";
+            this.chkEnableSsl.Size = new System.Drawing.Size(79, 15);
+            this.chkEnableSsl.TabIndex = 15;
+            this.chkEnableSsl.Text = "Enable SSL";
+            this.chkEnableSsl.UseVisualStyleBackColor = true;
+            this.chkEnableSsl.CheckedChanged += new System.EventHandler(this.chkEnableSsl_CheckedChanged);
+            // 
             // lblInstallSubFolder
             // 
             this.lblInstallSubFolder.AutoSize = true;
@@ -120,7 +146,7 @@
             // 
             this.txtInstallSubFolder.Location = new System.Drawing.Point(323, 169);
             this.txtInstallSubFolder.Name = "txtInstallSubFolder";
-            this.txtInstallSubFolder.Size = new System.Drawing.Size(217, 23);
+            this.txtInstallSubFolder.Size = new System.Drawing.Size(273, 23);
             this.txtInstallSubFolder.TabIndex = 13;
             // 
             // txtSiteNameSuffix
@@ -128,7 +154,7 @@
             this.txtSiteNameSuffix.FontWeight = MetroFramework.MetroTextBoxWeight.Light;
             this.txtSiteNameSuffix.Location = new System.Drawing.Point(323, 37);
             this.txtSiteNameSuffix.Name = "txtSiteNameSuffix";
-            this.txtSiteNameSuffix.Size = new System.Drawing.Size(217, 23);
+            this.txtSiteNameSuffix.Size = new System.Drawing.Size(273, 23);
             this.txtSiteNameSuffix.TabIndex = 12;
             this.txtSiteNameSuffix.Text = ".dnndev.me";
             // 
@@ -364,7 +390,7 @@
             this.tabControl.Location = new System.Drawing.Point(3, 14);
             this.tabControl.Multiline = true;
             this.tabControl.Name = "tabControl";
-            this.tabControl.SelectedIndex = 0;
+            this.tabControl.SelectedIndex = 1;
             this.tabControl.Size = new System.Drawing.Size(607, 294);
             this.tabControl.TabIndex = 26;
             // 
@@ -737,5 +763,7 @@
         private MetroFramework.Controls.MetroComboBox cboProductVersion;
         private MetroFramework.Controls.MetroTile tileDNNCommunity;
         private MetroFramework.Controls.MetroButton btnViewExistingSites;
+        private MetroFramework.Controls.MetroCheckBox chkEnableSsl;
+        private MetroFramework.Controls.MetroComboBox cboCertificates;
     }
 }

--- a/nvQuickSite/app.config
+++ b/nvQuickSite/app.config
@@ -52,6 +52,12 @@
             <setting name="EnableLocalPackageInstall" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="EnableSsl" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="CertificateFriendlyName" serializeAs="String">
+                <value />
+            </setting>
         </nvQuickSite.Properties.Settings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup>
@@ -59,7 +65,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/nvQuickSite/data/latestVersion.json
+++ b/nvQuickSite/data/latestVersion.json
@@ -1,3 +1,3 @@
 ﻿{
-  "latestVersion": "2.2.0"
+  "latestVersion": "2.3.0"
 }

--- a/nvQuickSite/nvQuickSite.csproj
+++ b/nvQuickSite/nvQuickSite.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-	<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{3D661BAD-45EB-4524-9650-78805CD31682}</ProjectGuid>
@@ -279,7 +279,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
+      <Version>13.0.2</Version>
     </PackageReference>
     <PackageReference Include="Octokit">
       <Version>0.32.0</Version>


### PR DESCRIPTION
Resolves #353 

Now there is a new checkbox for `Enable SSL`.  When checked, this populates a list of all available certificates for use on an IIS site.

![image](https://user-images.githubusercontent.com/4568451/216863233-f38daa5c-0c46-482e-8c06-6a861be8794d.png)

![image](https://user-images.githubusercontent.com/4568451/216863237-4026c25d-45ba-43ba-bb6d-ef92e76c3160.png)
