### PR TITLE
Update minimum installer requirements for .NET Framework 4.7.2+

### DIFF
--- a/nvQuickSiteWixInstaller/Product.wxs
+++ b/nvQuickSiteWixInstaller/Product.wxs
@@ -8,8 +8,8 @@
 
 		<MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
 
-		<PropertyRef Id="NETFRAMEWORK45" />
-		<Launch Condition="Installed OR NETFRAMEWORK45" Message="This application requires .NET Framework 4.5. Please install the .NET Framework then run this installer again." />
+		<PropertyRef Id="WIX_IS_NETFRAMEWORK_472_OR_LATER_INSTALLED" />
+		<Launch Condition="Installed OR WIX_IS_NETFRAMEWORK_472_OR_LATER_INSTALLED" Message="This application requires .NET Framework 4.7.2 or later. Please install .NET Framework 4.72 or later and run this installer again." />
 
 		<DirectoryRef Id="ApplicationProgramsFolder">
 			<Component Id="ApplicationShortcut">


### PR DESCRIPTION
This PR updates the Wix installer check for .NET Framework to 4.7.2+ and will install if it doesn't exist.

Resolves #392 