### PR TITLE
Updated to support having multiple RCs

### DIFF
--- a/nvQuickSite/Extensions/VersionExtensions.cs
+++ b/nvQuickSite/Extensions/VersionExtensions.cs
@@ -1,0 +1,26 @@
+﻿namespace nvQuickSite.Extensions
+{
+    using System;
+
+    /// <summary>
+    /// Extension methods for <see cref="Version"/> objects.
+    /// </summary>
+    public static class VersionExtensions
+    {
+        /// <summary>
+        /// Converts  a DotNet Version into a semantic version string.
+        /// </summary>
+        /// <param name="version">The version to convert.</param>
+        /// <returns>9.13.8 or 10.0.0-rc1 for example.</returns>
+        public static string ToSemanticString(this Version version)
+        {
+            var baseVersion = version.ToString(3);
+            if (version.Revision > 0)
+            {
+                return $"{baseVersion}-rc{version.Revision}";
+            }
+
+            return baseVersion;
+        }
+    }
+}

--- a/nvQuickSite/Models/Package.cs
+++ b/nvQuickSite/Models/Package.cs
@@ -17,12 +17,15 @@
 
 namespace nvQuickSite.Models
 {
+    using System.Diagnostics;
+
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
 
     /// <summary>
     /// Represents one package.
     /// </summary>
+    [DebuggerDisplay("{did} {version}")]
     public class Package
     {
         /// <summary>

--- a/nvQuickSite/Start.cs
+++ b/nvQuickSite/Start.cs
@@ -36,6 +36,7 @@ namespace nvQuickSite
     using nvQuickSite.Controls.Settings;
     using nvQuickSite.Controls.Sites;
     using nvQuickSite.Exceptions;
+    using nvQuickSite.Extensions;
     using nvQuickSite.Models;
     using Ookii.Dialogs;
     using Serilog;
@@ -190,7 +191,7 @@ namespace nvQuickSite
             this.cboProductVersion.Items.Clear();
             foreach (var package in this.Packages.Where(p => p.did == packageId).OrderByDescending(p => p.version))
             {
-                this.cboProductVersion.Items.Add(new ComboItem(package.version.ToString(), package.version.ToString()));
+                this.cboProductVersion.Items.Add(new ComboItem(package.version.ToSemanticString(), package.version.ToString()));
             }
 
             if (this.cboProductVersion.Items.Count > 0)
@@ -222,7 +223,9 @@ namespace nvQuickSite
             Package package;
             var fileName = string.Empty;
 
-            package = this.Packages.FirstOrDefault(p => p.did == ((ComboItem)this.cboProductName.SelectedItem).Value && p.version == new System.Version(((ComboItem)this.cboProductVersion.SelectedItem).Value));
+            package = this.Packages.FirstOrDefault(p =>
+                p.did == ((ComboItem)this.cboProductName.SelectedItem).Value &&
+                p.version == new System.Version(((ComboItem)this.cboProductVersion.SelectedItem).Value));
             fileName = package.url.Split('/').Last();
 
             var downloadDirectory = FileSystemController.GetDownloadDirectory();

--- a/nvQuickSite/nvQuickSite.csproj
+++ b/nvQuickSite/nvQuickSite.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Controllers\PackageExtractorController.cs" />
     <Compile Include="Controllers\VersionController.cs" />
     <Compile Include="Controllers\Exceptions\VersionControllerException.cs" />
+    <Compile Include="Extensions\VersionExtensions.cs" />
     <Compile Include="Models\Package.cs" />
     <Compile Include="Models\Version.cs" />
     <Compile Include="Controls\Dialogs\MsgBoxOk.cs">


### PR DESCRIPTION
In the current state, only one RC at a time was supported. With major releases having a longer period in RC we may need to release minor/patch releases to the previous version while we have a major version RC out there.

This updates the tool to support any RC that did not have yet a non-rc release published by the same version.

![image](https://github.com/user-attachments/assets/1e0b7b10-e14a-4d89-8bef-65fb36d66386)

![image](https://github.com/user-attachments/assets/1527f5bf-af64-452f-ac47-c4751be9774e)
